### PR TITLE
feat: bootstrap time tracking frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:4000

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "prettier"]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --frozen-lockfile || npm install
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/node_modules ./node_modules
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@/lib/zod-resolver";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/hooks/useAuth";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ErrorToast } from "@/components/error-toast";
+import { Loader2, LogIn } from "lucide-react";
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6)
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { login } = useAuth();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: "", password: "" }
+  });
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    setSubmitError(null);
+    try {
+      await login(values);
+      router.push("/clock");
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : "Invalid credentials");
+    }
+  });
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/40 p-6">
+      <ErrorToast error={submitError} />
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-2 text-center">
+          <CardTitle className="flex items-center justify-center gap-2 text-2xl font-semibold">
+            <LogIn className="h-6 w-6" />
+            Time Tracking Login
+          </CardTitle>
+          <CardDescription>Use your corporate credentials to sign in.</CardDescription>
+        </CardHeader>
+        <form onSubmit={onSubmit} className="space-y-6">
+          <CardContent className="space-y-4">
+            <div className="space-y-2 text-left">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" type="email" placeholder="you@company.com" {...form.register("email")} />
+              {form.formState.errors.email && (
+                <p className="text-sm text-destructive">{form.formState.errors.email.message}</p>
+              )}
+            </div>
+            <div className="space-y-2 text-left">
+              <Label htmlFor="password">Password</Label>
+              <Input id="password" type="password" {...form.register("password")} />
+              {form.formState.errors.password && (
+                <p className="text-sm text-destructive">{form.formState.errors.password.message}</p>
+              )}
+            </div>
+          </CardContent>
+          <CardFooter>
+            <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
+              {form.formState.isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Sign in
+            </Button>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/app/approvals/page.tsx
+++ b/app/approvals/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/services/api";
+import { RoleGuard } from "@/components/role-guard";
+import { ApprovalsTable, ApprovalRequest } from "@/components/approvals-table";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { toast } from "sonner";
+
+export default function ApprovalsPage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const approvalsQuery = useQuery({
+    queryKey: ["approvals"],
+    queryFn: () => apiClient.get<ApprovalRequest[]>("/approvals")
+  });
+
+  const approveMutation = useMutation({
+    mutationFn: (ids: string[]) => apiClient.post("/approvals/bulk-approve", { ids }),
+    onSuccess: () => {
+      toast.success("Requests approved");
+      queryClient.invalidateQueries({ queryKey: ["approvals"] });
+      queryClient.invalidateQueries({ queryKey: ["timesheet"] });
+    }
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: (ids: string[]) => apiClient.post("/approvals/bulk-reject", { ids }),
+    onSuccess: () => {
+      toast.success("Requests rejected");
+      queryClient.invalidateQueries({ queryKey: ["approvals"] });
+      queryClient.invalidateQueries({ queryKey: ["timesheet"] });
+    }
+  });
+
+  return (
+    <RoleGuard roles={["MANAGER", "ADMIN"]} onRequireLogin={() => router.push("/login")}> 
+      <div className="mx-auto flex max-w-5xl flex-col gap-6 p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Approvals</CardTitle>
+            <CardDescription>Review pending timesheet adjustments and approve or reject in bulk.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ApprovalsTable
+              requests={approvalsQuery.data ?? []}
+              onApprove={(ids) => approveMutation.mutateAsync(ids)}
+              onReject={(ids) => rejectMutation.mutateAsync(ids)}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    </RoleGuard>
+  );
+}

--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { apiClient } from "@/services/api";
+import { TimeEntry } from "@/hooks/useTimeClock";
+import { TimeClockCard } from "@/components/time-clock-card";
+import { TimesheetTable } from "@/components/timesheet-table";
+import { RoleGuard } from "@/components/role-guard";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { minutesToHHMM } from "@/utils/time";
+
+export default function ClockPage() {
+  const router = useRouter();
+  const todayQuery = useQuery({
+    queryKey: ["timesheet", "today"],
+    queryFn: () => apiClient.get<TimeEntry[]>("/timesheet/today")
+  });
+
+  const totals = useMemo(() => {
+    const entries = todayQuery.data ?? [];
+    const normal = entries.filter((entry) => entry.type === "NORMAL").reduce((acc, entry) => acc + entry.minutes, 0);
+    const overtime = entries.filter((entry) => entry.type === "OVERTIME").reduce((acc, entry) => acc + entry.minutes, 0);
+    return {
+      normal: minutesToHHMM(normal),
+      overtime: minutesToHHMM(overtime)
+    };
+  }, [todayQuery.data]);
+
+  return (
+    <RoleGuard roles={["EMPLOYEE", "MANAGER", "ADMIN"]} onRequireLogin={() => router.push("/login")}> 
+      <div className="mx-auto flex max-w-5xl flex-col gap-8 p-6">
+        <TimeClockCard />
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Today&apos;s Summary</CardTitle>
+            </CardHeader>
+            <CardContent className="grid gap-2 text-sm">
+              <div className="flex items-center justify-between rounded-md border bg-muted/40 p-3">
+                <span className="font-medium text-muted-foreground">Normal</span>
+                <span className="font-semibold text-emerald-600">{totals.normal}</span>
+              </div>
+              <div className="flex items-center justify-between rounded-md border bg-muted/40 p-3">
+                <span className="font-medium text-muted-foreground">Overtime</span>
+                <span className="font-semibold text-amber-600">{totals.overtime}</span>
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="md:col-span-2">
+            <CardHeader>
+              <CardTitle>Today&apos;s entries</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <TimesheetTable entries={todayQuery.data ?? []} />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </RoleGuard>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,52 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+
+  --primary: 221.2 83.2% 53.3%;
+  --primary-foreground: 210 40% 98%;
+
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 221.2 83.2% 53.3%;
+
+  --radius: 0.75rem;
+}
+
+* {
+  @apply border-border;
+}
+
+body {
+  @apply bg-background text-foreground;
+}
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+textarea:-webkit-autofill,
+select:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0px 1000px white inset;
+  -webkit-text-fill-color: hsl(var(--foreground));
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { ReactNode } from "react";
+import { QueryProvider } from "@/components/query-provider";
+import { Toaster } from "sonner";
+
+export const metadata: Metadata = {
+  title: "Time Tracking Portal",
+  description: "Manage work hours, approvals, and reports"
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-screen bg-background font-sans antialiased">
+        <QueryProvider>
+          {children}
+          <Toaster richColors position="top-right" />
+        </QueryProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function Home() {
+  redirect("/clock");
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "@/services/api";
+import { RoleGuard } from "@/components/role-guard";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useCurrentUser } from "@/hooks/useAuth";
+
+interface ScheduleItem {
+  day: string;
+  start: string;
+  end: string;
+}
+
+interface ProfileResponse {
+  jobTitle?: string;
+  department?: string;
+  schedule: ScheduleItem[];
+}
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const user = useCurrentUser();
+  const { data } = useQuery({
+    queryKey: ["profile"],
+    queryFn: () => apiClient.get<ProfileResponse>("/profile")
+  });
+
+  return (
+    <RoleGuard roles={["EMPLOYEE", "MANAGER", "ADMIN"]} onRequireLogin={() => router.push("/login")}> 
+      <div className="mx-auto flex max-w-4xl flex-col gap-6 p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Profile</CardTitle>
+            <CardDescription>Review your basic information and working schedule.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="rounded-lg border bg-muted/40 p-4">
+              <h2 className="text-lg font-semibold">{user?.name}</h2>
+              <p className="text-sm text-muted-foreground">{user?.email}</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {user?.roles.map((role) => (
+                  <Badge key={role} variant={role === "ADMIN" ? "destructive" : role === "MANAGER" ? "warning" : "secondary"}>
+                    {role}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+            <div className="rounded-lg border bg-background p-4">
+              <h3 className="mb-3 text-base font-semibold">Work schedule</h3>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Day</TableHead>
+                    <TableHead>Start</TableHead>
+                    <TableHead>End</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data?.schedule.map((item) => (
+                    <TableRow key={item.day}>
+                      <TableCell>{item.day}</TableCell>
+                      <TableCell>{item.start}</TableCell>
+                      <TableCell>{item.end}</TableCell>
+                    </TableRow>
+                  ))}
+                  {(!data || data.schedule.length === 0) && (
+                    <TableRow>
+                      <TableCell colSpan={3} className="py-6 text-center text-sm text-muted-foreground">
+                        Schedule not configured.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </RoleGuard>
+  );
+}

--- a/app/reports/my-week/page.tsx
+++ b/app/reports/my-week/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "@/services/api";
+import { RoleGuard } from "@/components/role-guard";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { WeeklyHoursChart, WeeklyHoursDataPoint } from "@/components/weekly-hours-chart";
+import { minutesToHHMM } from "@/utils/time";
+
+interface WeeklySummary {
+  weekStart: string;
+  weekEnd: string;
+  totals: {
+    regularMinutes: number;
+    overtimeMinutes: number;
+  };
+  chart: WeeklyHoursDataPoint[];
+}
+
+export default function MyWeekReportPage() {
+  const router = useRouter();
+  const { data } = useQuery({
+    queryKey: ["reports", "my-week"],
+    queryFn: () => apiClient.get<WeeklySummary>("/reports/my-week")
+  });
+
+  const regular = data?.totals.regularMinutes ?? 0;
+  const overtime = data?.totals.overtimeMinutes ?? 0;
+
+  return (
+    <RoleGuard roles={["EMPLOYEE", "MANAGER", "ADMIN"]} onRequireLogin={() => router.push("/login")}> 
+      <div className="mx-auto flex max-w-5xl flex-col gap-6 p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>My week</CardTitle>
+            <CardDescription>
+              {data
+                ? `Week of ${new Date(data.weekStart).toLocaleDateString()} – ${new Date(data.weekEnd).toLocaleDateString()}`
+                : "Loading weekly summary"}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="rounded-lg border bg-muted/30 p-4">
+                <p className="text-sm text-muted-foreground">Normal hours</p>
+                <p className="text-3xl font-semibold text-emerald-600">{minutesToHHMM(regular)}</p>
+              </div>
+              <div className="rounded-lg border bg-muted/30 p-4">
+                <p className="text-sm text-muted-foreground">Overtime hours</p>
+                <p className="text-3xl font-semibold text-amber-600">{minutesToHHMM(overtime)}</p>
+              </div>
+            </div>
+            <WeeklyHoursChart data={data?.chart ?? []} />
+          </CardContent>
+        </Card>
+      </div>
+    </RoleGuard>
+  );
+}

--- a/app/reports/summary/page.tsx
+++ b/app/reports/summary/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { formatISO } from "date-fns";
+import { apiClient } from "@/services/api";
+import { RoleGuard } from "@/components/role-guard";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { DateRangePicker, DateRangeValue } from "@/components/date-range-picker";
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { minutesToHHMM } from "@/utils/time";
+import { toast } from "sonner";
+
+interface SummaryRow {
+  employeeId: string;
+  employeeName: string;
+  regularMinutes: number;
+  overtimeMinutes: number;
+  approvalsPending: number;
+}
+
+interface SummaryResponse {
+  rows: SummaryRow[];
+  totals: {
+    regularMinutes: number;
+    overtimeMinutes: number;
+  };
+}
+
+function buildQuery(range: DateRangeValue) {
+  const params = new URLSearchParams();
+  if (range.from) params.set("from", formatISO(range.from, { representation: "date" }));
+  if (range.to) params.set("to", formatISO(range.to, { representation: "date" }));
+  const search = params.toString();
+  return search ? `?${search}` : "";
+}
+
+export default function SummaryReportPage() {
+  const router = useRouter();
+  const [range, setRange] = useState<DateRangeValue>({});
+
+  const summaryQuery = useQuery({
+    queryKey: ["reports", "summary", range],
+    queryFn: () => apiClient.get<SummaryResponse>(`/reports/summary${buildQuery(range)}`)
+  });
+
+  const rows = summaryQuery.data?.rows ?? [];
+  const totals = summaryQuery.data?.totals ?? { regularMinutes: 0, overtimeMinutes: 0 };
+
+  const handleExport = async () => {
+    try {
+      const csv = await apiClient.get<string>(`/reports/summary/export${buildQuery(range)}`);
+      const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", "summary-report.csv");
+      document.body.appendChild(link);
+      link.click();
+      link.parentNode?.removeChild(link);
+      URL.revokeObjectURL(url);
+      toast.success("Report exported");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to export report");
+    }
+  };
+
+  const totalEmployees = rows.length;
+  const totalMinutes = useMemo(() => totals.regularMinutes + totals.overtimeMinutes, [totals]);
+
+  return (
+    <RoleGuard roles={["MANAGER", "ADMIN"]} onRequireLogin={() => router.push("/login")}> 
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 p-6">
+        <Card>
+          <CardHeader className="gap-4 md:flex md:items-center md:justify-between">
+            <div>
+              <CardTitle>Summary report</CardTitle>
+              <CardDescription>Filter by date range and export detailed CSV results.</CardDescription>
+            </div>
+            <div className="flex flex-col gap-3 md:flex-row md:items-center">
+              <DateRangePicker value={range} onChange={setRange} />
+              <Button onClick={handleExport} variant="secondary">
+                Export CSV
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="rounded-lg border bg-muted/30 p-4 text-sm">
+                <p className="text-muted-foreground">Employees</p>
+                <p className="text-2xl font-semibold">{totalEmployees}</p>
+              </div>
+              <div className="rounded-lg border bg-muted/30 p-4 text-sm">
+                <p className="text-muted-foreground">Normal hours</p>
+                <p className="text-2xl font-semibold text-emerald-600">{minutesToHHMM(totals.regularMinutes)}</p>
+              </div>
+              <div className="rounded-lg border bg-muted/30 p-4 text-sm">
+                <p className="text-muted-foreground">Overtime hours</p>
+                <p className="text-2xl font-semibold text-amber-600">{minutesToHHMM(totals.overtimeMinutes)}</p>
+              </div>
+              <div className="rounded-lg border bg-muted/30 p-4 text-sm">
+                <p className="text-muted-foreground">Total hours</p>
+                <p className="text-2xl font-semibold">{minutesToHHMM(totalMinutes)}</p>
+              </div>
+            </div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Employee</TableHead>
+                  <TableHead>Normal</TableHead>
+                  <TableHead>Overtime</TableHead>
+                  <TableHead>Total</TableHead>
+                  <TableHead>Pending approvals</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.employeeId}>
+                    <TableCell>{row.employeeName}</TableCell>
+                    <TableCell>{minutesToHHMM(row.regularMinutes)}</TableCell>
+                    <TableCell>{minutesToHHMM(row.overtimeMinutes)}</TableCell>
+                    <TableCell>{minutesToHHMM(row.regularMinutes + row.overtimeMinutes)}</TableCell>
+                    <TableCell>{row.approvalsPending}</TableCell>
+                  </TableRow>
+                ))}
+                {rows.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={5} className="py-8 text-center text-sm text-muted-foreground">
+                      No data for the selected range.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </RoleGuard>
+  );
+}

--- a/app/settings/policy/page.tsx
+++ b/app/settings/policy/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@/lib/zod-resolver";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/services/api";
+import { RoleGuard } from "@/components/role-guard";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+
+const schema = z.object({
+  policyText: z.string().min(10, "Policy must be at least 10 characters"),
+  overtimeThreshold: z.number({ invalid_type_error: "Enter a number" }).min(0).max(24)
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface PolicyResponse {
+  policyText: string;
+  overtimeThreshold: number;
+}
+
+export default function PolicySettingsPage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const policyQuery = useQuery({
+    queryKey: ["settings", "policy"],
+    queryFn: () => apiClient.get<PolicyResponse>("/settings/policy")
+  });
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    values: policyQuery.data ?? {
+      policyText: "",
+      overtimeThreshold: 8
+    }
+  });
+
+  useEffect(() => {
+    if (policyQuery.data) {
+      form.reset(policyQuery.data);
+    }
+  }, [policyQuery.data, form]);
+
+  const updatePolicy = useMutation({
+    mutationFn: (values: FormValues) => apiClient.put("/settings/policy", values),
+    onSuccess: () => {
+      toast.success("Policy updated");
+      queryClient.invalidateQueries({ queryKey: ["settings", "policy"] });
+    }
+  });
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    await updatePolicy.mutateAsync(values);
+  });
+
+  return (
+    <RoleGuard roles={["ADMIN"]} onRequireLogin={() => router.push("/login")}> 
+      <div className="mx-auto flex max-w-4xl flex-col gap-6 p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Time tracking policy</CardTitle>
+            <CardDescription>Update company policy details and overtime thresholds.</CardDescription>
+          </CardHeader>
+          <form onSubmit={onSubmit}>
+            <CardContent className="space-y-6">
+              <div className="space-y-2">
+                <Label htmlFor="policyText">Policy</Label>
+                <Textarea id="policyText" rows={8} {...form.register("policyText")} />
+                {form.formState.errors.policyText && (
+                  <p className="text-sm text-destructive">{form.formState.errors.policyText.message}</p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="overtimeThreshold">Daily overtime threshold (hours)</Label>
+                <input
+                  id="overtimeThreshold"
+                  type="number"
+                  step="0.5"
+                  min={0}
+                  max={24}
+                  className="h-10 w-32 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  {...form.register("overtimeThreshold", { valueAsNumber: true })}
+                />
+                {form.formState.errors.overtimeThreshold && (
+                  <p className="text-sm text-destructive">{form.formState.errors.overtimeThreshold.message}</p>
+                )}
+              </div>
+            </CardContent>
+            <CardFooter className="justify-end gap-2">
+              <Button type="button" variant="ghost" onClick={() => form.reset(policyQuery.data)}>
+                Reset
+              </Button>
+              <Button type="submit" disabled={updatePolicy.isPending}>
+                {updatePolicy.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Save changes
+              </Button>
+            </CardFooter>
+          </form>
+        </Card>
+      </div>
+    </RoleGuard>
+  );
+}

--- a/app/timesheet/page.tsx
+++ b/app/timesheet/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { apiClient } from "@/services/api";
+import { TimeEntry } from "@/hooks/useTimeClock";
+import { TimesheetTable } from "@/components/timesheet-table";
+import { RoleGuard } from "@/components/role-guard";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { toast } from "sonner";
+
+interface DailyTimesheet {
+  date: string;
+  entries: TimeEntry[];
+}
+
+export default function TimesheetPage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { data = [], isLoading } = useQuery({
+    queryKey: ["timesheet", "list"],
+    queryFn: () => apiClient.get<DailyTimesheet[]>("/timesheet")
+  });
+
+  const requestEdit = useMutation({
+    mutationFn: (payload: { entryId: string }) => apiClient.post(`/timesheet/${payload.entryId}/edit-request`, {}),
+    onSuccess: () => {
+      toast.success("Edit request submitted");
+      queryClient.invalidateQueries({ queryKey: ["timesheet"] });
+    }
+  });
+
+  return (
+    <RoleGuard roles={["EMPLOYEE", "MANAGER", "ADMIN"]} onRequireLogin={() => router.push("/login")}> 
+      <div className="mx-auto flex max-w-5xl flex-col gap-6 p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Timesheet</CardTitle>
+            <CardDescription>Review and manage your logged hours. Submit edit requests when needed.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {isLoading && <p className="text-sm text-muted-foreground">Loading timesheet…</p>}
+            {!isLoading &&
+              data.map((day) => (
+                <div key={day.date} className="space-y-3">
+                  <h3 className="text-lg font-semibold">{new Date(day.date).toLocaleDateString()}</h3>
+                  <TimesheetTable
+                    entries={day.entries}
+                    onRequestEdit={(entry) => {
+                      requestEdit.mutate({ entryId: entry.id });
+                    }}
+                  />
+                </div>
+              ))}
+            {!isLoading && data.length === 0 && <p className="text-sm text-muted-foreground">No entries yet.</p>}
+          </CardContent>
+        </Card>
+      </div>
+    </RoleGuard>
+  );
+}

--- a/components/approvals-table.tsx
+++ b/components/approvals-table.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import { minutesToHHMM, formatTimeRange } from "@/utils/time";
+import { Badge } from "@/components/ui/badge";
+
+export interface ApprovalRequest {
+  id: string;
+  employee: {
+    id: string;
+    name: string;
+  };
+  start: string;
+  end?: string | null;
+  minutes: number;
+  type: "NORMAL" | "OVERTIME";
+  note?: string | null;
+  status: "PENDING" | "APPROVED" | "REJECTED";
+}
+
+interface ApprovalsTableProps {
+  requests: ApprovalRequest[];
+  onApprove: (ids: string[]) => Promise<void> | void;
+  onReject: (ids: string[]) => Promise<void> | void;
+}
+
+export function ApprovalsTable({ requests, onApprove, onReject }: ApprovalsTableProps) {
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const pendingRequests = useMemo(() => requests.filter((request) => request.status === "PENDING"), [requests]);
+  const isAllSelected = pendingRequests.length > 0 && selected.length === pendingRequests.length;
+
+  const toggleAll = () => {
+    if (isAllSelected) {
+      setSelected([]);
+    } else {
+      setSelected(pendingRequests.map((request) => request.id));
+    }
+  };
+
+  const toggleOne = (id: string) => {
+    setSelected((prev) => (prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id]));
+  };
+
+  const handleApprove = async () => {
+    await onApprove(selected);
+    setSelected([]);
+  };
+
+  const handleReject = async () => {
+    await onReject(selected);
+    setSelected([]);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Button size="sm" disabled={selected.length === 0} onClick={handleApprove}>
+          Approve selected
+        </Button>
+        <Button size="sm" variant="destructive" disabled={selected.length === 0} onClick={handleReject}>
+          Reject selected
+        </Button>
+        <span className="text-sm text-muted-foreground">{selected.length} selected</span>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-12">
+              <Checkbox checked={isAllSelected} onChange={() => toggleAll()} aria-label="Select all pending requests" />
+            </TableHead>
+            <TableHead>Employee</TableHead>
+            <TableHead>Time</TableHead>
+            <TableHead>Duration</TableHead>
+            <TableHead>Type</TableHead>
+            <TableHead>Note</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {requests.map((request) => (
+            <TableRow key={request.id} data-state={selected.includes(request.id) ? "selected" : undefined}>
+              <TableCell>
+                {request.status === "PENDING" ? (
+                  <Checkbox
+                    checked={selected.includes(request.id)}
+                    onChange={() => toggleOne(request.id)}
+                    aria-label={`Select request for ${request.employee.name}`}
+                  />
+                ) : null}
+              </TableCell>
+              <TableCell>{request.employee.name}</TableCell>
+              <TableCell>{formatTimeRange(request.start, request.end)}</TableCell>
+              <TableCell>{minutesToHHMM(request.minutes)}</TableCell>
+              <TableCell>
+                <Badge variant={request.type === "NORMAL" ? "secondary" : "warning"}>
+                  {request.type === "NORMAL" ? "Normal" : "Overtime"}
+                </Badge>
+              </TableCell>
+              <TableCell className="max-w-md truncate" title={request.note ?? undefined}>
+                {request.note ?? "—"}
+              </TableCell>
+              <TableCell>
+                <Badge variant={request.status === "APPROVED" ? "success" : request.status === "REJECTED" ? "destructive" : "warning"}>
+                  {request.status.toLowerCase()}
+                </Badge>
+              </TableCell>
+            </TableRow>
+          ))}
+          {requests.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={7} className="py-10 text-center text-sm text-muted-foreground">
+                Nothing to review.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/components/date-range-picker.tsx
+++ b/components/date-range-picker.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { format } from "date-fns";
+import { Input } from "@/components/ui/input";
+
+export interface DateRangeValue {
+  from?: Date;
+  to?: Date;
+}
+
+interface DateRangePickerProps {
+  value: DateRangeValue;
+  onChange: (next: DateRangeValue) => void;
+}
+
+function toInputDate(date?: Date) {
+  return date ? format(date, "yyyy-MM-dd") : "";
+}
+
+export function DateRangePicker({ value, onChange }: DateRangePickerProps) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      <Input
+        type="date"
+        value={toInputDate(value.from)}
+        onChange={(event) => {
+          const next = event.target.value ? new Date(event.target.value) : undefined;
+          onChange({ ...value, from: next });
+        }}
+        aria-label="Start date"
+      />
+      <Input
+        type="date"
+        value={toInputDate(value.to)}
+        min={value.from ? format(value.from, "yyyy-MM-dd") : undefined}
+        onChange={(event) => {
+          const next = event.target.value ? new Date(event.target.value) : undefined;
+          onChange({ ...value, to: next });
+        }}
+        aria-label="End date"
+      />
+    </div>
+  );
+}

--- a/components/error-toast.tsx
+++ b/components/error-toast.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { toast } from "sonner";
+
+interface ErrorToastProps {
+  error?: string | null;
+}
+
+export function ErrorToast({ error }: ErrorToastProps) {
+  useEffect(() => {
+    if (error) {
+      toast.error(error);
+    }
+  }, [error]);
+
+  return null;
+}

--- a/components/query-provider.tsx
+++ b/components/query-provider.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/components/role-guard.tsx
+++ b/components/role-guard.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { ReactNode } from "react";
+import { useAuth, UserRole } from "@/hooks/useAuth";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Lock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface RoleGuardProps {
+  roles: UserRole[];
+  fallback?: ReactNode;
+  onRequireLogin?: () => void;
+  children: ReactNode;
+}
+
+export function RoleGuard({ roles, fallback, onRequireLogin, children }: RoleGuardProps) {
+  const { user, hasRole } = useAuth();
+
+  if (!user) {
+    return (
+      fallback ?? (
+        <Card className="mx-auto max-w-md">
+          <CardHeader className="flex flex-col items-center space-y-4 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <Lock className="h-6 w-6" />
+            </div>
+            <CardTitle>Sign in required</CardTitle>
+            <CardDescription>Please log in to access this section.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex justify-center">
+            <Button onClick={onRequireLogin}>Go to Login</Button>
+          </CardContent>
+        </Card>
+      )
+    );
+  }
+
+  if (!hasRole(roles)) {
+    return (
+      fallback ?? (
+        <Card className="mx-auto max-w-md">
+          <CardHeader className="flex flex-col items-center space-y-4 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <Lock className="h-6 w-6" />
+            </div>
+            <CardTitle>Insufficient permissions</CardTitle>
+            <CardDescription>You do not have the required role to view this page.</CardDescription>
+          </CardHeader>
+        </Card>
+      )
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/components/time-clock-card.tsx
+++ b/components/time-clock-card.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@/lib/zod-resolver";
+import { useTimeClock } from "@/hooks/useTimeClock";
+import { minutesToHHMM } from "@/utils/time";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+
+const formSchema = z.object({
+  note: z.string().max(200, "Note must be 200 characters or less").optional()
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+function formatElapsed(start?: string) {
+  if (!start) return "00:00:00";
+  const startDate = new Date(start).getTime();
+  const now = Date.now();
+  const elapsed = Math.max(0, Math.floor((now - startDate) / 1000));
+  const hours = Math.floor(elapsed / 3600)
+    .toString()
+    .padStart(2, "0");
+  const minutes = Math.floor((elapsed % 3600) / 60)
+    .toString()
+    .padStart(2, "0");
+  const seconds = Math.floor(elapsed % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+export function TimeClockCard() {
+  const { status, startClock, stopClock, isStarting, isStopping } = useTimeClock();
+  const [elapsed, setElapsed] = useState("00:00:00");
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { note: "" }
+  });
+
+  const activeSession = status?.activeSession ?? null;
+
+  useEffect(() => {
+    setElapsed(formatElapsed(activeSession?.start ?? undefined));
+    if (!activeSession?.start) return;
+
+    const interval = setInterval(() => {
+      setElapsed(formatElapsed(activeSession.start));
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [activeSession?.start]);
+
+  const todaysTotal = useMemo(() => status?.todaysTotalMinutes ?? 0, [status?.todaysTotalMinutes]);
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    try {
+      await startClock({ note: values.note });
+      toast.success("Clock started");
+      form.reset();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Unable to start clock");
+    }
+  });
+
+  const handleStop = async () => {
+    try {
+      await stopClock();
+      toast.success("Clock stopped");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Unable to stop clock");
+    }
+  };
+
+  return (
+    <Card className="max-w-2xl">
+      <CardHeader>
+        <CardTitle>Time Clock</CardTitle>
+        <CardDescription>Track your work session with a single click.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-2 rounded-lg border bg-muted/40 p-4 text-center">
+          <span className="text-xs uppercase text-muted-foreground">Current session</span>
+          <span className="text-4xl font-semibold tabular-nums">{elapsed}</span>
+          <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+            <Badge variant={activeSession ? "success" : "secondary"}>
+              {activeSession ? "Running" : "Stopped"}
+            </Badge>
+            <span>Total today: {minutesToHHMM(todaysTotal)}</span>
+          </div>
+        </div>
+
+        {!activeSession && (
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2 text-left">
+              <Label htmlFor="note">Session note</Label>
+              <Input id="note" placeholder="What are you working on?" {...form.register("note")} />
+              {form.formState.errors.note && (
+                <p className="text-sm text-destructive">{form.formState.errors.note.message}</p>
+              )}
+            </div>
+            <Button type="submit" disabled={isStarting} className="w-full">
+              {isStarting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Start session
+            </Button>
+          </form>
+        )}
+
+        {activeSession && (
+          <div className="space-y-2 rounded-md border border-destructive/40 bg-destructive/10 p-4 text-left">
+            <p className="text-sm font-medium">Started at {new Date(activeSession.start).toLocaleTimeString()}</p>
+            {activeSession.note && <p className="text-sm text-muted-foreground">Note: {activeSession.note}</p>}
+            <p className="text-xs text-muted-foreground">
+              You can stop the timer once you finish. The entry will be available in your timesheet.
+            </p>
+          </div>
+        )}
+      </CardContent>
+      {activeSession && (
+        <CardFooter className="justify-end">
+          <Button variant="destructive" onClick={handleStop} disabled={isStopping}>
+            {isStopping && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Stop session
+          </Button>
+        </CardFooter>
+      )}
+    </Card>
+  );
+}

--- a/components/timesheet-table.tsx
+++ b/components/timesheet-table.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { TimeEntry } from "@/hooks/useTimeClock";
+import { format, parseISO } from "date-fns";
+import { minutesToHHMM, formatTimeRange } from "@/utils/time";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface TimesheetTableProps {
+  entries: TimeEntry[];
+  onRequestEdit?: (entry: TimeEntry) => void;
+}
+
+const statusVariant: Record<TimeEntry["status"], "default" | "success" | "destructive" | "warning"> = {
+  APPROVED: "success",
+  PENDING: "warning",
+  REJECTED: "destructive"
+};
+
+const typeStyles: Record<TimeEntry["type"], string> = {
+  NORMAL: "bg-emerald-500/10 text-emerald-700",
+  OVERTIME: "bg-amber-500/10 text-amber-700"
+};
+
+export function TimesheetTable({ entries, onRequestEdit }: TimesheetTableProps) {
+  if (entries.length === 0) {
+    return <p className="text-sm text-muted-foreground">No entries for this day.</p>;
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Date</TableHead>
+          <TableHead>Time</TableHead>
+          <TableHead>Duration</TableHead>
+          <TableHead>Type</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Note</TableHead>
+          <TableHead className="text-right">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {entries.map((entry) => (
+          <TableRow key={entry.id}>
+            <TableCell>{format(parseISO(entry.start), "MMM d, yyyy")}</TableCell>
+            <TableCell>{formatTimeRange(entry.start, entry.end)}</TableCell>
+            <TableCell>{minutesToHHMM(entry.minutes)}</TableCell>
+            <TableCell>
+              <span className={cn("rounded-full px-2 py-0.5 text-xs font-semibold", typeStyles[entry.type])}>
+                {entry.type === "NORMAL" ? "Normal" : "Overtime"}
+              </span>
+            </TableCell>
+            <TableCell>
+              <Badge variant={statusVariant[entry.status]}>{entry.status.toLowerCase()}</Badge>
+            </TableCell>
+            <TableCell className="max-w-xs truncate" title={entry.note ?? undefined}>
+              {entry.note || "—"}
+            </TableCell>
+            <TableCell className="text-right">
+              {onRequestEdit && (
+                <Button variant="outline" size="sm" onClick={() => onRequestEdit(entry)}>
+                  Request edit
+                </Button>
+              )}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary: "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        outline: "text-foreground",
+        success: "border-transparent bg-emerald-500 text-emerald-50",
+        warning: "border-transparent bg-amber-500 text-amber-950",
+        destructive: "border-transparent bg-destructive text-destructive-foreground"
+      }
+    },
+    defaultVariants: {
+      variant: "default"
+    }
+  }
+);
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+import { ButtonHTMLAttributes, forwardRef } from "react";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        link: "text-primary underline-offset-4 hover:underline"
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10"
+      }
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default"
+    }
+  }
+);
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(({ className, variant, size, ...props }, ref) => {
+  return <button className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+});
+
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)} {...props} />
+));
+Card.displayName = "Card";
+
+const CardHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <h3 className={cn("text-2xl font-semibold leading-none tracking-tight", className)} {...props} />
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = ({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+  <p className={cn("text-sm text-muted-foreground", className)} {...props} />
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("p-6 pt-0", className)} {...props} />
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex items-center p-6 pt-0", className)} {...props} />
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+const Checkbox = forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, ...props }, ref) => (
+    <input
+      type="checkbox"
+      ref={ref}
+      className={cn(
+        "h-4 w-4 rounded border border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Checkbox.displayName = "Checkbox";
+
+export { Checkbox };

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { forwardRef, InputHTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = "Input";
+
+export { Input };

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Label = React.forwardRef<HTMLLabelElement, React.LabelHTMLAttributes<HTMLLabelElement>>(
+  ({ className, ...props }, ref) => <label ref={ref} className={cn("text-sm font-medium", className)} {...props} />
+);
+Label.displayName = "Label";
+
+export { Label };

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface NativeSelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+const Select = forwardRef<HTMLSelectElement, NativeSelectProps>(({ className, children, ...props }, ref) => {
+  return (
+    <select
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </select>
+  );
+});
+Select.displayName = "Select";
+
+export { Select };

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import * as React from "react";
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+  </div>
+));
+Table.displayName = "Table";
+
+const TableHeader = ({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) => (
+  <thead className={cn("[&_tr]:border-b", className)} {...props} />
+);
+TableHeader.displayName = "TableHeader";
+
+const TableBody = ({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) => (
+  <tbody className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+);
+TableBody.displayName = "TableBody";
+
+const TableFooter = ({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) => (
+  <tfoot className={cn("bg-primary font-medium text-primary-foreground", className)} {...props} />
+);
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(({ className, ...props }, ref) => (
+  <tr ref={ref} className={cn("border-b transition-colors hover:bg-muted/50", className)} {...props} />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn("h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(({ className, ...props }, ref) => (
+  <td ref={ref} className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)} {...props} />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = ({ className, ...props }: React.HTMLAttributes<HTMLTableCaptionElement>) => (
+  <caption className={cn("mt-4 text-sm text-muted-foreground", className)} {...props} />
+);
+TableCaption.displayName = "TableCaption";
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/components/weekly-hours-chart.tsx
+++ b/components/weekly-hours-chart.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from "recharts";
+
+export interface WeeklyHoursDataPoint {
+  day: string;
+  regularMinutes: number;
+  overtimeMinutes: number;
+}
+
+interface WeeklyHoursChartProps {
+  data: WeeklyHoursDataPoint[];
+}
+
+function minutesToHours(minutes: number) {
+  return Math.round((minutes / 60) * 100) / 100;
+}
+
+export function WeeklyHoursChart({ data }: WeeklyHoursChartProps) {
+  return (
+    <div className="h-80 w-full">
+      <ResponsiveContainer>
+        <BarChart data={data} margin={{ top: 16, right: 24, left: 0, bottom: 8 }}>
+          <XAxis dataKey="day" tickLine={false} axisLine={false} />
+          <YAxis tickFormatter={minutesToHours} tickLine={false} axisLine={false} />
+          <Tooltip formatter={(value: number) => `${minutesToHours(value)}h`} />
+          <Legend formatter={(value) => (value === "regularMinutes" ? "Normal" : "Overtime")} />
+          <Bar dataKey="regularMinutes" stackId="hours" fill="#2563eb" name="Normal" radius={[4, 4, 0, 0]} />
+          <Bar dataKey="overtimeMinutes" stackId="hours" fill="#f97316" name="Overtime" radius={[4, 4, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { apiClient, ApiError, AuthTokens, setOnUnauthorized } from "@/services/api";
+
+export type UserRole = "EMPLOYEE" | "MANAGER" | "ADMIN";
+
+export interface AuthUser {
+  id: string;
+  name: string;
+  email: string;
+  roles: UserRole[];
+  schedule?: string;
+}
+
+interface LoginInput {
+  email: string;
+  password: string;
+}
+
+interface AuthState {
+  user: AuthUser | null;
+  isLoading: boolean;
+  error: string | null;
+  login: (input: LoginInput) => Promise<void>;
+  logout: () => void;
+  setUser: (user: AuthUser | null) => void;
+  loadProfile: () => Promise<void>;
+  hasRole: (roles: UserRole | UserRole[]) => boolean;
+}
+
+interface LoginResponse {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn?: number;
+  user: AuthUser;
+}
+
+const calculateExpiry = (expiresIn?: number) => Date.now() + (expiresIn ?? 15 * 60) * 1000;
+
+const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      user: null,
+      isLoading: false,
+      error: null,
+      async login(input) {
+        set({ isLoading: true, error: null });
+        try {
+          const data = await apiClient.post<LoginResponse>("/auth/login", input, { auth: false });
+          const tokens: AuthTokens = {
+            accessToken: data.accessToken,
+            refreshToken: data.refreshToken,
+            expiresAt: calculateExpiry(data.expiresIn)
+          };
+          apiClient.setTokens(tokens);
+          set({ user: data.user, isLoading: false });
+        } catch (error) {
+          const message = error instanceof ApiError ? error.message : "Unable to login";
+          set({ error: message, isLoading: false });
+          throw error;
+        }
+      },
+      logout() {
+        apiClient.setTokens(null);
+        set({ user: null, error: null, isLoading: false });
+      },
+      setUser(user) {
+        set({ user });
+      },
+      async loadProfile() {
+        const profile = await apiClient.get<AuthUser>("/auth/me");
+        set({ user: profile });
+      },
+      hasRole(roleOrRoles) {
+        const roles = Array.isArray(roleOrRoles) ? roleOrRoles : [roleOrRoles];
+        const user = get().user;
+        if (!user) return false;
+        return roles.some((role) => user.roles.includes(role));
+      }
+    }),
+    {
+      name: "tt-auth-store",
+      partialize: (state) => ({ user: state.user })
+    }
+  )
+);
+
+setOnUnauthorized(() => {
+  useAuthStore.getState().logout();
+});
+
+export function useAuth() {
+  return useAuthStore();
+}
+
+export function useCurrentUser() {
+  return useAuthStore((state) => state.user);
+}

--- a/hooks/useTimeClock.ts
+++ b/hooks/useTimeClock.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/services/api";
+
+export interface TimeEntry {
+  id: string;
+  start: string;
+  end?: string | null;
+  minutes: number;
+  type: "NORMAL" | "OVERTIME";
+  note?: string | null;
+  status: "PENDING" | "APPROVED" | "REJECTED";
+}
+
+export interface TimeClockStatus {
+  activeSession: TimeEntry | null;
+  todaysTotalMinutes: number;
+}
+
+export interface StartClockInput {
+  note?: string;
+}
+
+export function useTimeClock() {
+  const queryClient = useQueryClient();
+
+  const statusQuery = useQuery({
+    queryKey: ["time-clock", "status"],
+    queryFn: () => apiClient.get<TimeClockStatus>("/clock/status")
+  });
+
+  const startMutation = useMutation({
+    mutationFn: (input: StartClockInput) => apiClient.post<TimeEntry>("/clock/start", input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["time-clock"] });
+      queryClient.invalidateQueries({ queryKey: ["timesheet"] });
+    }
+  });
+
+  const stopMutation = useMutation({
+    mutationFn: () => apiClient.post<TimeEntry>("/clock/stop"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["time-clock"] });
+      queryClient.invalidateQueries({ queryKey: ["timesheet"] });
+    }
+  });
+
+  return {
+    status: statusQuery.data,
+    isLoading: statusQuery.isLoading,
+    startClock: startMutation.mutateAsync,
+    stopClock: stopMutation.mutateAsync,
+    isStarting: startMutation.isPending,
+    isStopping: stopMutation.isPending
+  };
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/lib/zod-resolver.ts
+++ b/lib/zod-resolver.ts
@@ -1,0 +1,31 @@
+import { type Resolver } from "react-hook-form";
+import { type ZodTypeAny, ZodError, type z } from "zod";
+
+export function zodResolver<T extends ZodTypeAny>(schema: T): Resolver<z.infer<T>> {
+  return async (values) => {
+    try {
+      const data = await schema.parseAsync(values);
+      return {
+        values: data,
+        errors: {}
+      };
+    } catch (error) {
+      if (error instanceof ZodError) {
+        return {
+          values: {},
+          errors: error.errors.reduce((acc, current) => {
+            if (current.path.length === 0) return acc;
+            const field = current.path[0];
+            acc[field as string] = {
+              type: current.code,
+              message: current.message
+            } as any;
+            return acc;
+          }, {} as Record<string, any>)
+        };
+      }
+
+      throw error;
+    }
+  };
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "time-tracking-web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.20.0",
+    "classnames": "^2.5.1",
+    "date-fns": "^3.3.1",
+    "lucide-react": "^0.323.0",
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-hook-form": "^7.49.3",
+    "recharts": "^2.8.0",
+    "sonner": "^1.4.2",
+    "zustand": "^4.4.7",
+    "zod": "^3.22.4",
+    "tailwindcss-animate": "^1.0.7",
+    "clsx": "^2.1.0",
+    "tailwind-merge": "^2.2.2",
+    "class-variance-authority": "^0.7.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^20.11.24",
+    "@types/react": "^18.2.64",
+    "@types/react-dom": "^18.2.19",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "^14.1.0",
+    "jsdom": "^23.2.0",
+    "postcss": "^8.4.35",
+    "prettier": "^3.2.5",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vitest": "^1.2.2",
+    "@vitejs/plugin-react": "^4.2.1"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,0 +1,173 @@
+"use client";
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+}
+
+export class ApiError extends Error {
+  status: number;
+  data: unknown;
+
+  constructor(message: string, status: number, data: unknown) {
+    super(message);
+    this.status = status;
+    this.data = data;
+  }
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+const STORAGE_KEY = "tt_tokens";
+
+let tokens: AuthTokens | null = null;
+let refreshPromise: Promise<AuthTokens | null> | null = null;
+let onUnauthorizedCallback: (() => void) | null = null;
+
+export const tokenStorage = {
+  load(): AuthTokens | null {
+    if (tokens) {
+      return tokens;
+    }
+
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+
+    try {
+      tokens = JSON.parse(raw) as AuthTokens;
+      return tokens;
+    } catch (error) {
+      console.error("Failed to parse stored tokens", error);
+      return null;
+    }
+  },
+  save(next: AuthTokens | null) {
+    tokens = next;
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (next) {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }
+};
+
+export function setOnUnauthorized(callback: (() => void) | null) {
+  onUnauthorizedCallback = callback;
+}
+
+async function refreshTokens(): Promise<AuthTokens | null> {
+  const currentTokens = tokenStorage.load();
+  if (!currentTokens?.refreshToken) {
+    tokenStorage.save(null);
+    return null;
+  }
+
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      const response = await fetch(`${API_URL}/auth/refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken: currentTokens.refreshToken })
+      });
+
+      if (!response.ok) {
+        tokenStorage.save(null);
+        if (onUnauthorizedCallback) {
+          onUnauthorizedCallback();
+        }
+        return null;
+      }
+
+      const data = (await response.json()) as { accessToken: string; refreshToken?: string; expiresIn?: number };
+      const nextTokens: AuthTokens = {
+        accessToken: data.accessToken,
+        refreshToken: data.refreshToken ?? currentTokens.refreshToken,
+        expiresAt: Date.now() + (data.expiresIn ?? 15 * 60) * 1000
+      };
+      tokenStorage.save(nextTokens);
+      return nextTokens;
+    })().finally(() => {
+      refreshPromise = null;
+    });
+  }
+
+  return refreshPromise;
+}
+
+export interface RequestOptions extends RequestInit {
+  auth?: boolean;
+  skipRefresh?: boolean;
+}
+
+async function makeRequest<T>(path: string, { auth = true, skipRefresh = false, headers, ...init }: RequestOptions = {}): Promise<T> {
+  let activeTokens = tokenStorage.load();
+
+  if (auth && activeTokens?.accessToken) {
+    headers = {
+      ...headers,
+      Authorization: `Bearer ${activeTokens.accessToken}`
+    };
+  }
+
+  const response = await fetch(`${API_URL}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...headers
+    }
+  });
+
+  if (response.status === 401 && auth && !skipRefresh) {
+    const refreshed = await refreshTokens();
+    if (!refreshed) {
+      if (onUnauthorizedCallback) {
+        onUnauthorizedCallback();
+      }
+      throw new ApiError("Unauthorized", 401, null);
+    }
+    const nextHeaders = { ...(headers ?? {}) } as Record<string, string>;
+    delete nextHeaders.Authorization;
+    return makeRequest<T>(path, { auth, headers: nextHeaders, ...init, skipRefresh: true });
+  }
+
+  let data: unknown = null;
+  const text = await response.text();
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = text;
+    }
+  }
+
+  if (!response.ok) {
+    throw new ApiError(typeof data === "string" ? data : response.statusText, response.status, data);
+  }
+
+  return data as T;
+}
+
+export const apiClient = {
+  get: <T>(path: string, options?: RequestOptions) => makeRequest<T>(path, { ...options, method: "GET" }),
+  post: <T>(path: string, body?: unknown, options?: RequestOptions) =>
+    makeRequest<T>(path, { ...options, method: "POST", body: body ? JSON.stringify(body) : undefined }),
+  put: <T>(path: string, body?: unknown, options?: RequestOptions) =>
+    makeRequest<T>(path, { ...options, method: "PUT", body: body ? JSON.stringify(body) : undefined }),
+  patch: <T>(path: string, body?: unknown, options?: RequestOptions) =>
+    makeRequest<T>(path, { ...options, method: "PATCH", body: body ? JSON.stringify(body) : undefined }),
+  delete: <T>(path: string, options?: RequestOptions) => makeRequest<T>(path, { ...options, method: "DELETE" }),
+  setTokens(next: AuthTokens | null) {
+    tokenStorage.save(next);
+  },
+  getTokens() {
+    return tokenStorage.load();
+  }
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,72 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./pages/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./app/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))"
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))"
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))"
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))"
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))"
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))"
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))"
+        }
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)"
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" }
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" }
+        }
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out"
+      }
+    }
+  },
+  plugins: [require("tailwindcss-animate")]
+};
+
+export default config;

--- a/tests/role-guard.test.tsx
+++ b/tests/role-guard.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { RoleGuard } from "@/components/role-guard";
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: vi.fn()
+}));
+
+import { useAuth } from "@/hooks/useAuth";
+
+const mockUseAuth = vi.mocked(useAuth);
+
+describe("RoleGuard", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+  });
+
+  it("renders login prompt when user is missing", () => {
+    mockUseAuth.mockReturnValue({ user: null, hasRole: vi.fn(), logout: vi.fn() } as any);
+
+    render(
+      <RoleGuard roles={["EMPLOYEE"]}>
+        <p>Protected</p>
+      </RoleGuard>
+    );
+
+    expect(screen.getByText(/sign in required/i)).toBeInTheDocument();
+  });
+
+  it("renders fallback when user lacks role", () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: "1", name: "User", email: "user@test.com", roles: ["EMPLOYEE"] },
+      hasRole: vi.fn().mockReturnValue(false)
+    } as any);
+
+    render(
+      <RoleGuard roles={["MANAGER"]}>
+        <p>Protected</p>
+      </RoleGuard>
+    );
+
+    expect(screen.getByText(/insufficient permissions/i)).toBeInTheDocument();
+  });
+
+  it("renders children when role matches", () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: "1", name: "User", email: "user@test.com", roles: ["MANAGER"] },
+      hasRole: vi.fn().mockReturnValue(true)
+    } as any);
+
+    render(
+      <RoleGuard roles={["MANAGER"]}>
+        <p>Protected</p>
+      </RoleGuard>
+    );
+
+    expect(screen.getByText("Protected")).toBeInTheDocument();
+  });
+});

--- a/tests/time-clock-card.test.tsx
+++ b/tests/time-clock-card.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+import { TimeClockCard } from "@/components/time-clock-card";
+
+vi.mock("@/hooks/useTimeClock", () => ({
+  useTimeClock: vi.fn()
+}));
+
+import { useTimeClock } from "@/hooks/useTimeClock";
+
+const mockUseTimeClock = vi.mocked(useTimeClock);
+
+describe("TimeClockCard", () => {
+  beforeEach(() => {
+    mockUseTimeClock.mockReset();
+  });
+
+  it("shows start button when there is no active session", () => {
+    mockUseTimeClock.mockReturnValue({
+      status: { activeSession: null, todaysTotalMinutes: 0 },
+      isLoading: false,
+      startClock: vi.fn(),
+      stopClock: vi.fn(),
+      isStarting: false,
+      isStopping: false
+    });
+
+    render(<TimeClockCard />);
+
+    expect(screen.getByRole("button", { name: /start session/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /stop session/i })).toBeDisabled();
+  });
+
+  it("shows stop button when there is an active session", () => {
+    mockUseTimeClock.mockReturnValue({
+      status: {
+        activeSession: {
+          id: "1",
+          start: new Date().toISOString(),
+          minutes: 5,
+          type: "NORMAL",
+          status: "PENDING"
+        },
+        todaysTotalMinutes: 30
+      },
+      isLoading: false,
+      startClock: vi.fn(),
+      stopClock: vi.fn(),
+      isStarting: false,
+      isStopping: false
+    });
+
+    render(<TimeClockCard />);
+
+    expect(screen.getByRole("button", { name: /stop session/i })).toBeEnabled();
+  });
+
+  it("calls stopClock when stop button is clicked", () => {
+    const stopClock = vi.fn().mockResolvedValue(undefined);
+    mockUseTimeClock.mockReturnValue({
+      status: {
+        activeSession: {
+          id: "1",
+          start: new Date().toISOString(),
+          minutes: 5,
+          type: "NORMAL",
+          status: "PENDING"
+        },
+        todaysTotalMinutes: 30
+      },
+      isLoading: false,
+      startClock: vi.fn(),
+      stopClock,
+      isStarting: false,
+      isStopping: false
+    });
+
+    render(<TimeClockCard />);
+
+    fireEvent.click(screen.getByRole("button", { name: /stop session/i }));
+    expect(stopClock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,42 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": [
+      "vitest/globals",
+      "@testing-library/jest-dom"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs",
+    "**/*.mjs"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -1,0 +1,26 @@
+import { format, parseISO } from "date-fns";
+
+export function formatDuration(totalMinutes: number): string {
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  const parts = [];
+  if (hours) parts.push(`${hours}h`);
+  if (minutes || parts.length === 0) parts.push(`${minutes}m`);
+  return parts.join(" ");
+}
+
+export function minutesToHHMM(totalMinutes: number): string {
+  const hours = Math.floor(totalMinutes / 60)
+    .toString()
+    .padStart(2, "0");
+  const minutes = (totalMinutes % 60).toString().padStart(2, "0");
+  return `${hours}:${minutes}`;
+}
+
+export function formatTimeRange(start: string, end?: string | null) {
+  const startDate = parseISO(start);
+  const endDate = end ? parseISO(end) : null;
+  const startString = format(startDate, "HH:mm");
+  const endString = endDate ? format(endDate, "HH:mm") : "--:--";
+  return `${startString} - ${endString}`;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    globals: true
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, ".")
+    }
+  }
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 app router project with Tailwind, Zustand auth store, custom fetch API client, and JWT-aware hooks
- implement core time tracking UI including time clock, timesheet, approvals, reports, settings, and profile pages with reusable components
- add vitest/react-testing-library coverage for TimeClockCard and RoleGuard plus Dockerfile, environment template, and project configuration

## Testing
- npm install *(fails: registry returns 403 for scoped packages such as @tanstack/react-query in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68d5218e6fe4832faa7ba2748c5f148a